### PR TITLE
LOG-10916 Python3 compatibility, do not fall back to plain text by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Rapid7 Insight Logger
-=================
+=====================
 
 This is a plugin library to enable logging to Rapid7 Insight from the Python Logger.
 Additionally this plugin allows the user to get an overview of methods being executed,

--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,6 @@ Metric.Time()
 
 This decorator function is used to log the execution time of given function. In the above example ``@TEST.time()`` will wrap ``function_one`` and send log message containing the name and execution time of this function.
 
-
-
 Configure
 ---------
 
@@ -83,10 +81,13 @@ In your R7Insight account, create a logfile, selecting ``Token TCP`` as
 the source\_type. This will print a Token UUID. This
 is the value to use for ``TOKEN``.
 
-The appender will attempt to send your log data over TLS over port 443,
-otherwise it will send over port 80.
+The appender will attempt to send your log data over TLS over port 443. You can also choose to not
+use TLS, in which case it will be sent over port 80.
+If the ``allow_plaintext_fallback`` option in the constructor is set to ``True``, then the library
+will automatically fall back to an insecure connection on port 80 if TLS is not supported on the
+host system.
 
-You are now ready to start logging
+You are now ready to start logging.
 
 Contact Support
 ===============

--- a/r7insight/__init__.py
+++ b/r7insight/__init__.py
@@ -1,1 +1,1 @@
-from utils import R7InsightHandler
+from .utils import R7InsightHandler

--- a/r7insight/utils.py
+++ b/r7insight/utils.py
@@ -145,11 +145,7 @@ else:
                 certfile=None,
                 server_side=False,
                 cert_reqs=ssl.CERT_REQUIRED,
-                ssl_version=getattr(
-                    ssl,
-                    'PROTOCOL_TLSv1_2',
-                    ssl.PROTOCOL_TLSv1
-                ),
+                ssl_version=ssl.PROTOCOL_TLSv1_2,
                 ca_certs=certifi.where(),
                 do_handshake_on_connect=True,
                 suppress_ragged_eofs=True,

--- a/r7insight/utils.py
+++ b/r7insight/utils.py
@@ -131,13 +131,12 @@ SocketAppender = PlainTextSocketAppender
 
 try:
     import ssl
-    ssl_enabled = True
+    ssl_supported = True
 except ImportError:  # for systems without TLS support.
-    ssl_enabled = False
-    dbg("Unable to import ssl module. Will send over port 80.")
+    ssl_supported = False
+    dbg("Unable to import ssl module.")
 else:
     class TLSSocketAppender(PlainTextSocketAppender):
-
         def open_connection(self):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock = ssl.wrap_socket(
@@ -159,9 +158,10 @@ else:
             sock.connect((self.le_data, self.le_tls_port))
             self._conn = sock
 
-
 class R7InsightHandler(logging.Handler):
-    def __init__(self, token, region, use_tls=True, verbose=True, format=None, le_data=LE_ENDPOINT_DEFAULT, le_port=LE_PORT_DEFAULT, le_tls_port=LE_TLS_PORT_DEFAULT):
+    def __init__(self, token, region, use_tls=True, verbose=True, format=None,
+    le_data=LE_ENDPOINT_DEFAULT, le_port=LE_PORT_DEFAULT, le_tls_port=LE_TLS_PORT_DEFAULT,
+    allow_plaintext_fallback=False):
         logging.Handler.__init__(self)
         self.token = token
         self.region = region
@@ -188,10 +188,12 @@ class R7InsightHandler(logging.Handler):
         self.setFormatter(format)
 
         self.setLevel(logging.DEBUG)
-        if use_tls and ssl_enabled:
-            self._thread = TLSSocketAppender(verbose=verbose, le_data=le_data, le_port=le_port, le_tls_port=le_tls_port)
-        else:
+
+        if not use_tls or (not ssl_supported and allow_plaintext_fallback):
             self._thread = SocketAppender(verbose=verbose, le_data=le_data, le_port=le_port, le_tls_port=le_tls_port)
+            return
+
+        self._thread = TLSSocketAppender(verbose=verbose, le_data=le_data, le_port=le_port, le_tls_port=le_tls_port)
 
     def flush(self):
         # wait for all queued logs to be send

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ with open('README.rst', 'r') as f:
 setup(
     name='r7insight_python',
     version='0.9.2',
-    author='Mark Lacomber',
-    author_email='marklacomber@gmail.com',
+    author='Rapid7',
+    author_email='InsightOpsTeam@rapid7.com',
     packages=['r7insight'],
     scripts=[],
     url='http://pypi.python.org/pypi/R7Insight/',
@@ -23,6 +23,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2'
-    ]
-)
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
+    ])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='r7insight_python',
-    version='0.9.2',
+    version='1.0.0',
     author='Rapid7',
     author_email='InsightOpsTeam@rapid7.com',
     packages=['r7insight'],


### PR DESCRIPTION
* Fixed Python3 compatibility
* Made sure the library doesn't fall back to plain text by default. If this fallback is desired it can be enabled by setting `allow_plaintext_fallback` to `True` in the constructor.