### PR TITLE
Use SSLContext.wrap_socket when ssl.wrap_socket when not available

### DIFF
--- a/r7insight/utils.py
+++ b/r7insight/utils.py
@@ -139,17 +139,28 @@ else:
     class TLSSocketAppender(PlainTextSocketAppender):
         def open_connection(self):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock = ssl.wrap_socket(
-                sock=sock,
-                keyfile=None,
-                certfile=None,
-                server_side=False,
-                cert_reqs=ssl.CERT_REQUIRED,
-                ssl_version=ssl.PROTOCOL_TLSv1_2,
-                ca_certs=certifi.where(),
-                do_handshake_on_connect=True,
-                suppress_ragged_eofs=True,
-            )
+            try:
+                sock = ssl.wrap_socket(
+                    sock=sock,
+                    keyfile=None,
+                    certfile=None,
+                    server_side=False,
+                    cert_reqs=ssl.CERT_REQUIRED,
+                    ssl_version=ssl.PROTOCOL_TLSv1_2,
+                    ca_certs=certifi.where(),
+                    do_handshake_on_connect=True,
+                    suppress_ragged_eofs=True,
+                )
+            except AttributeError:
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                context.verify_mode = ssl.CERT_REQUIRED
+                context.load_verify_locations(cafile=certifi.where())
+                sock = context.wrap_socket(
+                    sock=sock,
+                    server_hostname=self.le_data,
+                    do_handshake_on_connect=True,
+                    suppress_ragged_eofs=True
+                )
 
             sock.connect((self.le_data, self.le_tls_port))
             self._conn = sock


### PR DESCRIPTION
In Python 3.12 ssl.wrap_socket() has been removed, this PR uses ssl.SSLContext.wrap_socket if the former is not available. It probably addresses #9.